### PR TITLE
feat: Allow daily stats to be exposed in Gatsby

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,20 @@ query MyQuery {
 }
 ```
 
+### Plugin Options
+
+See the Covid19PluginOptions type in src/nodes/types.ts
+
 ## Contributing
 
 This plugin is still pretty barebones, so pull requests are more than welcome.
+
+Ways to help
+
+[] Get Jest up and running with some tests
+[] Dynamically fetch data from the Gatsby GraphQL queries?
+[] Make the Gatsby GraphQL nodes feel more native
+[] Nest related data structures in GraphQL
 
 ## Supporting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1378,6 +1378,12 @@
       "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.21.0.tgz",
+      "integrity": "sha512-Zhrf65tpjOlVIYrUhX9eu1VzRo8iixQDLFPbfqFxPpG4pBTNNPZ2BFhYE0IAsDfW9GWg+RcrUqiLwrGJH4rq4w==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -9782,6 +9788,11 @@
         "pseudomap": "^1.0.1",
         "yallist": "^2.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.0.tgz",
+      "integrity": "sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw=="
     },
     "make-dir": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/luxon": "^1.21.0",
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",
     "eslint": "^6.8.0",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
-    "gatsby-core-utils": "^1.0.33"
+    "gatsby-core-utils": "^1.0.33",
+    "luxon": "^1.22.0"
   }
 }

--- a/src/api-client/daily.ts
+++ b/src/api-client/daily.ts
@@ -1,0 +1,45 @@
+import { GetHTTPClient, DailySummaryEntry, DailyProvinceStateEntry } from './types'
+import { DateLike } from '../types'
+import { dateToStr } from './util'
+
+export interface DailySummaryResponse {
+  data: DailySummaryEntry[]
+}
+
+export interface GetDateRequest {
+  date: DateLike
+}
+
+export interface GetDateResponse {
+  data: DailyProvinceStateEntry[]
+}
+
+export default class DailyStore {
+  constructor (private readonly client: GetHTTPClient) {}
+
+  /**
+   * Summaries for each day since the data epoch (~2020-01-20)
+   */
+  async getSummary (): Promise<DailySummaryResponse> {
+    const url = '/api/daily'
+
+    return this.client.get(url)
+  }
+
+  /**
+   * Cases per region sorted by confirmed cases
+   *
+   * NOTE: Data seems to be available starting 2020-01-22
+   */
+  async getDate (input: GetDateRequest): Promise<GetDateResponse> {
+    if (!input.date) {
+      throw new TypeError('"date" is a required field')
+    }
+
+    const date = dateToStr(input.date)
+
+    const url = `/api/daily/${date}`
+
+    return this.client.get(url)
+  }
+}

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -1,9 +1,22 @@
-import Axios, { AxiosInstance } from 'axios'
+import Axios from 'axios'
 import CountryStore from './country'
+import DailyStore from './daily'
 import GlobalStore from './global'
+import { GetHTTPClient } from './types'
 
 interface APIClientOptions {
-  baseURL: string
+  /**
+   * OPTIONAL Use an alternate domain for the API
+   *
+   * Defaults to the value in DEFAULT_OPTIONS.baseURL
+   */
+  baseURL?: string
+  /**
+   * OPTIONAL Provide an initialised Axios client with the baseURL set
+   *
+   * Defaults to a new Axios client with the baseURL
+   */
+  httpClient?: GetHTTPClient
 }
 
 const DEFAULT_OPTIONS = {
@@ -11,15 +24,21 @@ const DEFAULT_OPTIONS = {
 }
 
 export default class APIClient {
-  private readonly httpClient: AxiosInstance
+  private readonly httpClient: GetHTTPClient
   public countries: CountryStore
+  public daily: DailyStore
   public global: GlobalStore
 
-  constructor (opts: Partial<APIClientOptions> = {}) {
-    const baseURL = opts.baseURL ?? DEFAULT_OPTIONS.baseURL
+  constructor (opts: APIClientOptions = {}) {
+    if (!opts.httpClient) {
+      const baseURL = opts.baseURL ?? DEFAULT_OPTIONS.baseURL
+      this.httpClient = Axios.create({ baseURL })
+    } else {
+      this.httpClient = opts.httpClient
+    }
 
-    this.httpClient = Axios.create({ baseURL })
     this.countries = new CountryStore(this.httpClient)
     this.global = new GlobalStore(this.httpClient)
+    this.daily = new DailyStore(this.httpClient)
   }
 }

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios'
-import { ISOCountryCode, URLString, ISO8601Timestamp, ISO2CountryCode, ISO3CountryCode } from '../types'
+import { ISOCountryCode, URLString, ISO8601Timestamp, ISO2CountryCode, ISO3CountryCode, ISO8601Date } from '../types'
 
 export interface CountryRegionDetailRequest {
   country: ISOCountryCode
@@ -34,6 +34,27 @@ export interface ProvinceStateDetail {
   deaths: number
   active: number
   lastUpdate: ISO8601Timestamp
+}
+
+export interface DailySummaryEntry {
+  objectid: number
+  reportDate: number
+  reportDateString: ISO8601Date
+  mainlandChina: number
+  otherLocations: number
+  totalConfirmed: number
+  totalRecovered: number | null
+  deltaConfirmed: number
+  deltaRecovered: number | null
+}
+
+export interface DailyProvinceStateEntry {
+  provinceState: string | null
+  countryRegion: string
+  lastUpdate: ISO8601Timestamp
+  confirmed: string
+  deaths: string
+  recovered: string
 }
 
 export type GetHTTPClient = Pick<AxiosInstance, 'get'>

--- a/src/api-client/util.ts
+++ b/src/api-client/util.ts
@@ -1,0 +1,27 @@
+import { DateLike, ISO8601Date } from '../types'
+
+const ISO_DATE_REGEXP = new RegExp('20[0-9]{2}-[0-9]{2}-[0-9]{2}')
+
+export function dateLikeToDate (date: DateLike): Date {
+  if (date instanceof Date) {
+    return date
+  }
+  const parsed = new Date(date)
+
+  const parsedYear = parsed.getUTCFullYear()
+  if (parsedYear < 2020 || parsedYear > 2030) {
+    console.warn(`[gatsby-source-mathdroid-covid19] Invalid date provided: '${date.toString()}'`)
+  }
+
+  return parsed
+}
+
+export function dateToStr (date: DateLike): ISO8601Date {
+  if (typeof date === 'string' && ISO_DATE_REGEXP.test(date)) {
+    return date
+  }
+
+  const parsed = dateLikeToDate(date)
+
+  return parsed.toISOString().split('T')[0]
+}

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -1,9 +1,11 @@
 import { SourceNodesArgs } from 'gatsby'
 import APIClient from './api-client'
+import { Covid19PluginOptions, ResolverContext } from './nodes/types'
 import resolveCountries from './nodes/countries'
+import resolveDailyNodes from './nodes/daily'
+import resolveDailySummaryNodes from './nodes/daily-summary'
 import resolveGlobal from './nodes/global'
 import resolveProvinceStateNodes from './nodes/provinces'
-import { Covid19PluginOptions, ResolverContext } from './nodes/types'
 
 export const sourceNodes = async (nodeKit: SourceNodesArgs, pluginOptions: Covid19PluginOptions): Promise<void> => {
   const apiClient = new APIClient({
@@ -17,6 +19,8 @@ export const sourceNodes = async (nodeKit: SourceNodesArgs, pluginOptions: Covid
   }
 
   await resolveProvinceStateNodes(ctx)
-  await resolveGlobal(ctx)
   await resolveCountries(ctx)
+  await resolveGlobal(ctx)
+  await resolveDailySummaryNodes(ctx)
+  await resolveDailyNodes(ctx)
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,4 @@
+
+export function warn (message: string, ...optionalParams: any[]): void {
+  console.warn(`[gatsby-source-mathdroid-covid19] ${message}`, ...optionalParams)
+}

--- a/src/nodes/daily-summary.ts
+++ b/src/nodes/daily-summary.ts
@@ -1,0 +1,78 @@
+import { SourceNodesArgs, NodeInput } from 'gatsby'
+import { ResolverContext, NodeTypes } from './types'
+import { ISO8601Date } from '../types'
+import { DailySummaryEntry } from '../api-client/types'
+import { dateToStr } from '../api-client/util'
+
+export interface DailySummaryNode extends NodeInput {
+  reportDate: ISO8601Date
+
+  mainlandChina: number
+  otherLocations: number
+
+  totalConfirmed: number
+  totalRecovered: number | null
+
+  deltaConfirmed: number
+  deltaRecovered: number | null
+}
+
+export function toDailySummaryNode (
+  kit: SourceNodesArgs,
+  result: DailySummaryEntry
+): DailySummaryNode {
+  const {
+    mainlandChina,
+    otherLocations,
+    totalConfirmed,
+    totalRecovered,
+    deltaConfirmed,
+    deltaRecovered
+  } = result
+
+  // Yes, there's a reportDateString, but it's formatted with '/'
+  const reportDate = dateToStr(result.reportDate)
+
+  const node: DailySummaryNode = {
+    id: kit.createNodeId(`daily-summary-${reportDate}`),
+    reportDate,
+
+    mainlandChina,
+    otherLocations,
+
+    totalConfirmed,
+    totalRecovered,
+    deltaConfirmed,
+    deltaRecovered,
+
+    internal: {
+      type: NodeTypes.DailySummary,
+      contentDigest: ''
+    }
+  }
+
+  node.internal.contentDigest = kit.createContentDigest(JSON.stringify(node))
+
+  return node
+}
+
+export default async function resolveDailySummaryNodes (ctx: ResolverContext): Promise<void> {
+  const { apiClient, nodeKit, pluginOptions } = ctx
+  const { actions: { createNode } } = nodeKit
+
+  if (!pluginOptions.dailySummary) {
+    return
+  }
+
+  const result = await apiClient.daily.getSummary()
+
+  if (!result) {
+    return
+  }
+
+  result.data.forEach((entry) => {
+    const node = toDailySummaryNode(nodeKit, entry)
+
+    createNode(node)
+  })
+}

--- a/src/nodes/daily.ts
+++ b/src/nodes/daily.ts
@@ -1,0 +1,115 @@
+import { SourceNodesArgs, NodeInput } from 'gatsby'
+import { DateTime } from 'luxon'
+import { ResolverContext, NodeTypes } from './types'
+import { ISO8601Timestamp, DateLike, ISO8601Date } from '../types'
+import { dateToStr } from '../api-client/util'
+import { DailyProvinceStateEntry } from '../api-client/types'
+import { toProvinceID } from './util'
+import * as logger from '../logger'
+
+export interface DailyProvinceStateNode extends NodeInput {
+  reportDate: ISO8601Date
+  provinceState: string | null
+  countryRegion: string
+  lastUpdate: ISO8601Timestamp
+  confirmed: number
+  deaths: number
+  recovered: number
+}
+
+export function toDailyProvinceStateNode (
+  kit: SourceNodesArgs,
+  reportDate: ISO8601Date,
+  result: DailyProvinceStateEntry
+): DailyProvinceStateNode {
+  const {
+    provinceState,
+    countryRegion,
+    lastUpdate,
+    confirmed,
+    deaths,
+    recovered
+  } = result
+
+  const provinceId = toProvinceID(result)
+
+  const node: DailyProvinceStateNode = {
+    id: kit.createNodeId(`daily-${reportDate}-${provinceId}`),
+    reportDate,
+    provinceState,
+    countryRegion,
+    lastUpdate,
+    confirmed: parseInt(confirmed, 10),
+    deaths: parseInt(deaths, 10),
+    recovered: parseInt(recovered, 10),
+    internal: {
+      type: NodeTypes.DailyProvinceStateDetail,
+      contentDigest: ''
+    }
+  }
+
+  node.internal.contentDigest = kit.createContentDigest(JSON.stringify(node))
+
+  return node
+}
+
+export default async function resolveDailyNodes (ctx: ResolverContext): Promise<void> {
+  const { pluginOptions, apiClient, nodeKit } = ctx
+  const { actions: { createNode } } = nodeKit
+
+  if (!pluginOptions.daily) {
+    return
+  }
+
+  const opts = pluginOptions.daily
+
+  const datesToFetch: DateLike[] = []
+
+  if (opts.dates) {
+    datesToFetch.push(...opts.dates)
+  }
+  if (opts.relativeDays) {
+    if (opts.relativeDays < 0) {
+      throw TypeError(`Expected ${opts.relativeDays} to be a positive integer`)
+    }
+
+    const today = DateTime.utc().startOf('day')
+    for (let i = opts.relativeDays; i > 0; i--) {
+      const date = today.minus({ days: i }).toISODate()
+
+      datesToFetch.push(date)
+    }
+  }
+
+  const promises = datesToFetch.map(async (dateLike) => {
+    const date = dateToStr(dateLike) // We need this to be a string for IDs above anyway
+
+    let result
+
+    try {
+      result = await apiClient.daily.getDate({ date })
+    } catch (err) {
+      if (err.response && err.response.status === 404) {
+        logger.warn(`Data is not available for ${date}`)
+
+        return
+      }
+
+      console.dir(err)
+
+      throw err
+    }
+
+    if (!result) {
+      return
+    }
+
+    result.data.forEach((entry) => {
+      const node = toDailyProvinceStateNode(nodeKit, date, entry)
+
+      createNode(node)
+    })
+  })
+
+  await Promise.all(promises)
+}

--- a/src/nodes/provinces.ts
+++ b/src/nodes/provinces.ts
@@ -1,6 +1,7 @@
 import { SourceNodesArgs, NodeInput } from 'gatsby'
 import { ProvinceStateDetail } from '../api-client/types'
 import { ResolverContext, NodeTypes } from './types'
+import { toProvinceID } from './util'
 
 export interface ProvinceStateDetailNode extends NodeInput {
   provinceState: string | null
@@ -35,8 +36,10 @@ export function toProvinceStateNode (
     deaths
   } = result
 
+  const provinceId = toProvinceID(result)
+
   const node: ProvinceStateDetailNode = {
-    id: kit.createNodeId([result.iso2, result.provinceState, 'detail'].join('-')),
+    id: kit.createNodeId(`detail-${provinceId}`),
     iso2,
     iso3,
     provinceState,

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -1,8 +1,11 @@
 import { SourceNodesArgs } from 'gatsby'
 import APIClient from '../api-client'
+import { DateLike } from '../types'
 
 export enum NodeTypes {
   CountrySummary = 'Covid19CountrySummary',
+  DailySummary = 'Covid19DailySummary',
+  DailyProvinceStateDetail = 'Covid19DailyProvinceStateDetail',
   GlobalSummary = 'Covid19GlobalSummary',
   ProvinceStateDetail = 'Covid19ProvinceStateDetail'
 }
@@ -11,9 +14,41 @@ interface CountryConfiguration {
   iso2: string
 }
 
+interface DailyConfiguration {
+  /**
+   * Positive integer of days prior to today to fetch
+   *
+   * @example 1 will only fetch yesterday
+   */
+  relativeDays?: number
+  /**
+   * Fetch data for specific days
+   */
+  dates?: DateLike[]
+}
+
 export interface Covid19PluginOptions {
   baseURL?: string
   countries: CountryConfiguration[]
+
+  /**
+   * Add nodes for the global summary (/api)
+   *
+   * Defaults to true for backwards compatibility
+   */
+  globalSummary?: boolean
+  /**
+   * Add nodes for the daily summary (/api/daily)
+   *
+   * Defaults to false
+   */
+  dailySummary?: boolean
+  /**
+   * Add nodes for detailed days (/api/daily/[date])
+   *
+   * Defaults to false
+   */
+  daily?: DailyConfiguration
 }
 
 export interface ResolverContext {

--- a/src/nodes/util.ts
+++ b/src/nodes/util.ts
@@ -1,0 +1,9 @@
+
+interface ProvinceNode {
+  provinceState: string | null
+  countryRegion: string
+}
+
+export function toProvinceID (obj: ProvinceNode): string {
+  return [obj.provinceState, obj.countryRegion].join(':')
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,18 @@
+/**
+ * A timestamp in ISO8601 format with milliseconds
+ *
+ * @example "2020-03-16T18:33:03.000Z"
+ */
 export type ISO8601Timestamp = string
+/** A date in the format YYYY-MM-DD */
+export type ISO8601Date = string
+/** Unix epoch in milliseconds */
+export type EpochMillis = number
+
+export type DateLike = Date | ISO8601Date | EpochMillis
+
 export type ISO2CountryCode = string
 export type ISO3CountryCode = string
 export type ISOCountryCode = ISO2CountryCode | ISO3CountryCode
+
 export type URLString = string


### PR DESCRIPTION
Expose the daily stats functionality from mathdro.id's API. (`/api/daily` and `/api/daily/[date]`)

* add DailyStore to APIClient
* add plugin options for dailySummary and daily
* create nodes for DailySummary and DailyProvinceStateSummary
* update README.md